### PR TITLE
Fixed #44 Use HTTPs for font link href

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <title>Kyber Wallet 0.0.1</title>
     <!-- change this up! http://www.bootstrapcdn.com/bootswatch/ -->
     <link href="foundation.min.css" type="text/css" rel="stylesheet"/>
-    <link href='http://fonts.googleapis.com/css?family=Roboto:300, 400, 500, 700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:300, 400, 500, 700' rel='stylesheet' type='text/css'>
     <link href="/assets/app.css" type="text/css" rel="stylesheet"/>
     <!--
     <link rel="stylesheet" type="text/css" href="/assets/plugins/selectric/selectric.css">


### PR DESCRIPTION
Under SSL, plain HTTP is not allowed by web server/browser. Change to HTTPS fixed problem #44 .