### PR TITLE
Add .crypto and .zil domain resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,6 +842,214 @@
         }
       }
     },
+    "@ensdomains/address-encoder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@ensdomains/address-encoder/-/address-encoder-0.2.0.tgz",
+      "integrity": "sha512-HA2ABdFCirSMETXpvgbNtZapcoEBkTziCJXcmmJGIddb3WTmxSwVkQFvJcEjUdCcAe7imOqBlkPdf1P0529J5w==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "blakejs": "^1.1.0",
+        "bn.js": "^4.11.8",
+        "bs58": "^4.0.1",
+        "crypto-addr-codec": "^0.1.7",
+        "nano-base32": "^1.0.1",
+        "ripemd160": "^2.0.2"
+      }
+    },
+    "@ethersproject/abi": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.13.tgz",
+      "integrity": "sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==",
+      "requires": {
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+          "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+          "integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.10.tgz",
+      "integrity": "sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/networks": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/web": "^5.0.12"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz",
+      "integrity": "sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
+      }
+    },
     "@ethersproject/address": {
       "version": "5.0.0-beta.131",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.131.tgz",
@@ -853,6 +1061,29 @@
         "@ethersproject/logger": ">=5.0.0-beta.129",
         "@ethersproject/rlp": ">=5.0.0-beta.126",
         "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.9.tgz",
+      "integrity": "sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        }
       }
     },
     "@ethersproject/bignumber": {
@@ -882,6 +1113,107 @@
         "@ethersproject/bignumber": ">=5.0.0-beta.130"
       }
     },
+    "@ethersproject/hash": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.12.tgz",
+      "integrity": "sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+          "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+          "integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
     "@ethersproject/keccak256": {
       "version": "5.0.0-beta.130",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.130.tgz",
@@ -903,6 +1235,21 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.131.tgz",
       "integrity": "sha512-5WKvSvijhhQ5+7vCIJSU/fmxuGY2ENd+axeN/Gjk+0l1hZmYPSMvO4jJ1YSnu38BhhvI8aiVM3PDlmzAWwwv4g=="
     },
+    "@ethersproject/networks": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.9.tgz",
+      "integrity": "sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        }
+      }
+    },
     "@ethersproject/properties": {
       "version": "5.0.0-beta.133",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.133.tgz",
@@ -919,6 +1266,59 @@
         "@ethersproject/bytes": ">=5.0.0-beta.129"
       }
     },
+    "@ethersproject/signing-key": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.11.tgz",
+      "integrity": "sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "elliptic": "6.5.4"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        }
+      }
+    },
     "@ethersproject/strings": {
       "version": "5.0.0-beta.133",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.133.tgz",
@@ -927,6 +1327,161 @@
         "@ethersproject/bytes": ">=5.0.0-beta.129",
         "@ethersproject/constants": ">=5.0.0-beta.128",
         "@ethersproject/logger": ">=5.0.0-beta.129"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.11.tgz",
+      "integrity": "sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==",
+      "requires": {
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/rlp": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+          "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.14.tgz",
+      "integrity": "sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.11.tgz",
+          "integrity": "sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.10.tgz",
+          "integrity": "sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.10.tgz",
+          "integrity": "sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
       }
     },
     "@ledgerhq/devices": {
@@ -1024,6 +1579,36 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@unstoppabledomains/resolution": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@unstoppabledomains/resolution/-/resolution-2.1.1.tgz",
+      "integrity": "sha512-85nMILSvSW8iMGMFc98dHFFE5Iz/d0nNsVSPabiYiQLjgaBpIjgF/cda9ZSuXbAa07M77kmq2m2MKMDRrEBeWA==",
+      "requires": {
+        "@ensdomains/address-encoder": "0.2.0",
+        "@ethersproject/abi": "^5.0.1",
+        "bip44-constants": "^8.0.5",
+        "bn.js": "^4.4.0",
+        "commander": "^4.1.1",
+        "content-hash": "^2.5.2",
+        "dotenv": "^8.2.0",
+        "ethereum-ens-network-map": "^1.0.2",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
+      }
     },
     "@walletconnect/browser": {
       "version": "1.0.0-beta.38",
@@ -3042,6 +3627,14 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -3059,6 +3652,16 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -3426,6 +4029,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bip44-constants": {
+      "version": "8.0.103",
+      "resolved": "https://registry.npmjs.org/bip44-constants/-/bip44-constants-8.0.103.tgz",
+      "integrity": "sha512-wuGsY9IKUS9GC5Sf/Acb5jLJZI3Z8qsMoQHWldnQyoVUlij4y8e5srh28Iqul1HwK+elPsAYGNYKtYhovjvNxA=="
+    },
     "bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
@@ -3442,6 +4050,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -3669,6 +4282,14 @@
         "caniuse-lite": "^1.0.30000984",
         "electron-to-chromium": "^1.3.191",
         "node-releases": "^1.1.25"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
       }
     },
     "bser": {
@@ -4022,6 +4643,43 @@
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
+    "cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -4036,6 +4694,11 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
       "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
       "dev": true
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -4413,6 +5076,16 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "requires": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
+      }
+    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -4585,6 +5258,27 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "crypto-addr-codec": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
+      "integrity": "sha512-X4hzfBzNhy4mAc3UpiXEC/L0jo5E8wAa9unsnA8nNXYzXjCcGk83hfC5avJWCSGT8V91xMnAS9AKMHmjw5+XCg==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "big-integer": "1.6.36",
+        "blakejs": "^1.1.0",
+        "bs58": "^4.0.1",
+        "ripemd160-min": "0.0.6",
+        "safe-buffer": "^5.2.0",
+        "sha3": "^2.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "crypto-browserify": {
@@ -5279,6 +5973,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "optional": true
+    },
     "download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
@@ -5703,6 +6403,11 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+    },
+    "ethereum-ens-network-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.2.tgz",
+      "integrity": "sha512-5qwJ5n3YhjSpE6O/WEBXCAb2nagUgyagJ6C0lGUBWC4LjKp/rRzD+pwtDJ6KCiITFEAoX4eIrWOjRy0Sylq5Hg=="
     },
     "ethereumjs-common": {
       "version": "1.5.0",
@@ -6760,7 +7465,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6778,11 +7484,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6795,15 +7503,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6906,7 +7617,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6916,6 +7628,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6928,17 +7641,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6955,6 +7671,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7027,7 +7744,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7037,6 +7755,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7112,7 +7831,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7142,6 +7862,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7159,6 +7880,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7197,11 +7919,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10676,6 +11400,11 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -11607,6 +12336,31 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -11621,10 +12375,58 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
+    "multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
+      }
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "nano-base32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
+      "integrity": "sha1-ulSMh578+5DaHE2eCX20pGySVe8="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -12641,7 +13443,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pify": {
       "version": "4.0.1",
@@ -13770,16 +14573,6 @@
         "warning": "^4.0.1"
       }
     },
-    "react-router-redux": {
-      "version": "5.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz",
-      "integrity": "sha512-euSgNIANnRXr4GydIuwA7RZCefrLQzIw5WdXspS8NPYbV+FxrKSS9MKG7U9vb6vsKHONnA4VxrVNWfnMUnUQAw==",
-      "requires": {
-        "history": "^4.7.2",
-        "prop-types": "^15.6.0",
-        "react-router": "^4.2.0"
-      }
-    },
     "react-simple-dropdown": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/react-simple-dropdown/-/react-simple-dropdown-3.2.3.tgz",
@@ -14352,6 +15145,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "ripemd160-min": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+      "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A=="
+    },
     "rlp": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
@@ -14771,6 +15569,35 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "requires": {
+        "buffer": "6.0.3"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        }
       }
     },
     "shallow-clone": {
@@ -16783,6 +17610,11 @@
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
       "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -17918,8 +18750,7 @@
       "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.0",
-        "websocket": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.2.0"
       },
       "dependencies": {
         "debug": {
@@ -17932,7 +18763,7 @@
         },
         "websocket": {
           "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
+          "from": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14573,6 +14573,16 @@
         "warning": "^4.0.1"
       }
     },
+    "react-router-redux": {
+      "version": "5.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz",
+      "integrity": "sha512-euSgNIANnRXr4GydIuwA7RZCefrLQzIw5WdXspS8NPYbV+FxrKSS9MKG7U9vb6vsKHONnA4VxrVNWfnMUnUQAw==",
+      "requires": {
+        "history": "^4.7.2",
+        "prop-types": "^15.6.0",
+        "react-router": "^4.2.0"
+      }
+    },
     "react-simple-dropdown": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/react-simple-dropdown/-/react-simple-dropdown-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^4.56.0",
     "@ledgerhq/hw-transport-u2f": "^4.56.0",
+    "@unstoppabledomains/resolution": "^2.0.0",
     "@walletconnect/browser": "^1.0.0-beta.38",
     "abi-decoder": "^2.2.2",
     "babel-plugin-add-module-exports": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^4.56.0",
     "@ledgerhq/hw-transport-u2f": "^4.56.0",
-    "@unstoppabledomains/resolution": "^2.0.0",
+    "@unstoppabledomains/resolution": "^2.1.1",
     "@walletconnect/browser": "^1.0.0-beta.38",
     "abi-decoder": "^2.2.2",
     "babel-plugin-add-module-exports": "^1.0.0",


### PR DESCRIPTION
Extends feature of .eth resolution to support .crypto and .zil domains.
Learn more about Unstoppable Domains [here](https://docs.unstoppabledomains.com/)

Example of resolution:
![example](https://user-images.githubusercontent.com/23408540/111820229-7b504300-889e-11eb-8b83-f05bc694f3c3.gif)
